### PR TITLE
Fix renaming tracks on Sharp devices

### DIFF
--- a/src/services/netmd.ts
+++ b/src/services/netmd.ts
@@ -87,7 +87,9 @@ export class NetMDUSBService implements NetMDService {
     async renameTrack(index: number, title: string) {
         // Removing non ascii chars... Sorry, I didn't implement char encoding.
         title = sanitizeTitle(title);
+        await this.netmdInterface!.cacheTOC();
         await this.netmdInterface!.setTrackTitle(index, title);
+        await this.netmdInterface!.syncTOC();
     }
 
     async renameDisc(newName: string) {


### PR DESCRIPTION
The Sharp IM-DR420H requires `cacheTOC()` and `syncTOC()` calls in order to be able to rename tracks.

This might be required for other track manipulation options as well, but I haven't tested it. The inspiration for these calls is from `netmdcli.c`.